### PR TITLE
fixed parsing for titles with quotes, and for empty UserID

### DIFF
--- a/jobOne/Review.java
+++ b/jobOne/Review.java
@@ -31,12 +31,15 @@ public class Review {
 
     public Review(String reviewRow) {
 	  
-          String[] csvSplit = reviewRow.split(",");
+          String[] csvSplit = reviewRow.split(",(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)", -1);
           
           if(csvSplit.length < 10){
             positiveReview = false;  //discard if data point isnt valid
           }
           
+          else if(csvSplit[3].length() < 1){
+            positiveReview = false;
+          }
           else{
           
             bookTitle = csvSplit[1];


### PR DESCRIPTION
Parsing was not taking into account the possibility of titles having commas in it.  After looking through the file, it seems that any title that will contain a comma will also be wrapped in quotations, so we can parse for checking quotations, then ignoring commas inside that quotation.

Also ignores any lines that don't have UserID